### PR TITLE
[FIX] making writer more portable.

### DIFF
--- a/csvfaker/csvfaker.py
+++ b/csvfaker/csvfaker.py
@@ -69,7 +69,7 @@ def main():
         show_fakes()
         exit(0)
 
-    writer = csv.writer(sys.stdout, delimiter=args.delimiter)
+    writer = csv.writer(sys.stdout, delimiter=args.delimiter, lineterminator='\n')
     if args.headers:
         writer.writerow(args.methods)
 


### PR DESCRIPTION
- According to https://stackoverflow.com/a/3191811/7239409 any newline `\n` chars will get replaced with the windows sys default  carriage return newline `\r\n` 
- So if given `\r\n` you will end up with `\r\r\n` which renders just fine in a terminal but when you cat to file it will end up with extra carriage returns or white spaces.